### PR TITLE
Partners onto 3 rather than 4 per row

### DIFF
--- a/src/lib/Blocks/Partners.svelte
+++ b/src/lib/Blocks/Partners.svelte
@@ -120,7 +120,7 @@
 
   @media only screen and (min-width: 720px) {
     .b-partners__group__items--partners .b-partners__group__item {
-      width: calc(25% - 18px);
+      width: calc(33% - 18px);
     }
   }
 </style>


### PR DESCRIPTION
- Partners logos were not aligned nicely with 9 items due to displaying 4 per row
- Updated to render with 3 per row apart from on mobile where it is 2 per row as standard