### PR TITLE
Ensure 'more from the blog' articles show latest first

### DIFF
--- a/src/routes/latest/layout.svelte
+++ b/src/routes/latest/layout.svelte
@@ -32,6 +32,7 @@
   async function getLatestPosts() {
     const res = await fetch(`/latest/posts.json`);
     const { posts } = await res.json();
+    posts.sort((a, b) => Date.parse(b.date) - Date.parse(a.date));
     return posts;
   }
 


### PR DESCRIPTION
Articles displayed under the blog article were being displayed in alphabetical order rather than date order.

They now display the latest first.

I have checked in the code and there isn't anywhere else that needs changing.